### PR TITLE
Feature/rate limiting with memcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rate-limit
-PSR-7 Rate limiting using redis. predis is not needed for this middleware. It uses Tinyredisclient by ptrofimov.
+PSR-7 Rate limiting using Redis or Memcache. predis is not needed for this middleware. It uses Tinyredisclient by ptrofimov.
 
 ## Usage 
 The last constructor argument is the redis password. This is option. When it is not provided the middleware will connect without authenticating.
@@ -13,7 +13,13 @@ In this example the client is allowed to make 60 requests in 30 seconds.
 $rateLimitMiddleware->setRequestsPerSecond(60, 30);
 ```
 
-When the request limit has been reached the request statuscode is set to 429 by defaukt.
+When the request limit has been reached the request statuscode is set to 429 by default.
+
+By default the Redis is used as a storage. To use Memcache instead:
+
+```php
+$rateLimitMiddleware->useMemcache();
+```
 
 ## Custom handler when limit has been reached.
 

--- a/src/RateLimitMiddleware.php
+++ b/src/RateLimitMiddleware.php
@@ -99,11 +99,9 @@ class RateLimitMiddleware
         if ($this->storedRequestsCount($uniqueID) >= $this->maxRequests) {
             $handler = $this->limitHandler;
             return $handler($request, $response);
-        } else {
-            $this->storeNewRequest($uniqueID);
-            $response = $next($request, $response);
         }
 
-        return $response;
+        $this->storeNewRequest($uniqueID);
+        return $next($request, $response);
     }
 }

--- a/src/RateLimitMiddleware.php
+++ b/src/RateLimitMiddleware.php
@@ -71,14 +71,15 @@ class RateLimitMiddleware
 
         $this->maxRequests = $maxRequests;
         $this->seconds = $seconds;
+        return $this;
     }
 
     public function auth()
     {
-        if ($this->storageType !== self::REDIS) {
-            return;
+        if ($this->storageType === self::REDIS) {
+            $this->handle->auth($this->pass);
         }
-        $this->handle->auth($this->pass);
+        return $this;
     }
 
     public function useMemcache()
@@ -86,17 +87,20 @@ class RateLimitMiddleware
         $this->storageType = self::MEMCACHE;
         $this->handle = new \Memcache;
         $this->handle->connect($this->host, intval($this->port));
+        return $this;
     }
 
     public function useRedis()
     {
         $this->storageType = self::REDIS;
         $this->handle = new \TinyRedisClient(sprintf("%s:%s", $this->host, $this->port));
+        return $this;
     }
 
     public function setHandler($handler)
     {
         $this->limitHandler = $handler;
+        return $this;
     }
 
     protected function storedRequestsCount($uniqueID)

--- a/src/RateLimitMiddleware.php
+++ b/src/RateLimitMiddleware.php
@@ -68,9 +68,6 @@ class RateLimitMiddleware
         $this->seconds = $seconds;
     }
 
-    /**
-     *
-     */
     public function auth()
     {
         $this->handle->auth($this->pass);

--- a/src/RateLimitMiddleware.php
+++ b/src/RateLimitMiddleware.php
@@ -83,11 +83,11 @@ class RateLimitMiddleware
 
     public function __invoke(Request $request, Response $response, $next)
     {
-        if (count($this->handle->keys(sprintf("%s*", str_replace('.', '', $_SERVER['REMOTE_ADDR'])))) >= $this->maxRequests) {
+        if (count($this->handle->keys(sprintf("%s*", $_SERVER['REMOTE_ADDR']))) >= $this->maxRequests) {
             $handler = $this->limitHandler;
             return $handler($request, $response);
         } else {
-            $key = sprintf("%s%s", str_replace('.', '', $_SERVER['REMOTE_ADDR']), mt_rand());
+            $key = sprintf("%s%s", $_SERVER['REMOTE_ADDR'], mt_rand());
             $this->handle->set($key, time());
             $this->handle->expire($key, $this->seconds);
             $response = $next($request, $response);


### PR DESCRIPTION
I have improved somewhat your rate limiter. The notable changes are:

- It is now possible to use Memcache as a storage instead of Redis
- Fix a bug where IP addresses would be confused as the same address
- Less memory consumption for rate limiting